### PR TITLE
fix typo in pkgdown yml

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::., any::tidyverse, any::r2dii,plot
+          extra-packages: any::pkgdown, local::., any::tidyverse, any::r2dii.plot
           needs: website
 
       - name: Build site


### PR DESCRIPTION
Fixes a bug introduced in #431 

CI did not catch this bug, since all CI was failing at that stage for a different reason. 