### PR TITLE
fix company level sda targets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # r2dii.analysis (development version)
 
+# `target_sda` now uses final year of scenario as convergence target when `by_company = TRUE` (#445).
 # `target_market_share` gains argument `increasing_or_decreasing` (#426).
 
 # r2dii.analysis 0.2.1

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -371,8 +371,6 @@ compute_loanbook_targets <- function(data,
                                      scenario_with_p,
                                      by_company,
                                      ...) {
-  # groups_to_use_total <- c("sector", "scenario", "region", "scenario_source")
-
   target_summary_groups <- maybe_add_name_abcd(..., by_company)
 
   max_year_data <- max(data$year)
@@ -395,21 +393,6 @@ compute_loanbook_targets <- function(data,
         by = c("year", "sector", "region", "scenario_source")
       ) %>%
       dplyr::filter(!is.na(.data$name_abcd))
-
-    # data <- data %>%
-    #   group_by(!!!rlang::syms(...)) %>%
-    #   arrange(.data$year) %>%
-    #   tidyr::complete(.data$name_abcd, tidyr::nesting(year, emission_factor_projected, emission_factor_adjusted_scenario, p)) %>%
-    #   # tidyr::complete(tidyr::nesting(name_abcd, emission_factor_projected), tidyr::nesting(year, emission_factor_adjusted_scenario, p)) %>%
-    #   dplyr::mutate(
-    #     emission_factor_projected = dplyr::if_else(
-    #       .data$year > .env$max_year_data,
-    #       NA_real_,
-    #       .data$emission_factor_projected
-    #     )
-    #   ) %>%
-    #   ungroup() %>%
-    #   dplyr::filter(!is.na(.data$name_abcd))
   }
 
   data <- data  %>%

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -384,10 +384,10 @@ compute_loanbook_targets <- function(data,
       arrange(.data$year) %>%
       tidyr::complete(.data$name_abcd, year) %>%
       ungroup() %>%
-      select(-all_of(c("scenario", "emission_factor_adjusted_scenario", "p"))) %>%
+      select(-all_of(c("emission_factor_adjusted_scenario", "p"))) %>%
       right_join(
         scenario_with_p,
-        by = c("year", "sector", "region", "scenario_source")
+        by = c("year", "sector", "region", "scenario_source", "scenario")
       ) %>%
       dplyr::filter(!is.na(.data$name_abcd))
   }

--- a/R/target_sda.R
+++ b/R/target_sda.R
@@ -226,7 +226,6 @@ target_sda <- function(data,
     data,
     adjusted_scenario_with_p,
     by_company = by_company,
-    # !!!rlang::syms(target_summary_groups)
     target_summary_groups
   )
 
@@ -372,8 +371,6 @@ compute_loanbook_targets <- function(data,
                                      by_company,
                                      ...) {
   target_summary_groups <- maybe_add_name_abcd(..., by_company)
-
-  max_year_data <- max(data$year)
 
   data <- data %>%
     right_join(

--- a/tests/testthat/_snaps/target_sda.md
+++ b/tests/testthat/_snaps/target_sda.md
@@ -36,7 +36,7 @@
        7 cement  2020 global demo_2020       shaanxi auto target_b2ds           
        8 cement  2021 global demo_2020       shaanxi auto target_b2ds           
        9 cement  2022 global demo_2020       shaanxi auto target_b2ds           
-      10 cement  2023 global demo_2020       <NA>         target_b2ds           
+      10 cement  2023 global demo_2020       shaanxi auto target_b2ds           
       # i 58 more rows
       # i 1 more variable: emission_factor_value <dbl>
 


### PR DESCRIPTION
closes #445 

This PR:
- ensures that `target_sda(by_company = TRUE)` uses the emission intensity value of the final year of the `adjusted_scenario_*` to calculate the `target_*` values for companies when using the SDA approach
- this ensures that - regardless of whether the SDA is applied at company or loan book level - the individual scenario targets converge at the correct scenario value
- the issue had been caused by a `right_join`, that introduces `NAs` for every year past the emission intensity projection when running `target_sda()` at the company level.
- some implementation details:
  - previously, `target_summary_groups` was adjusted to loan book or company level at the top level of `target_sda()`
  - it is moved into `compute_loanbook_targets()`, which gains an argument, `by_company`, to adjust the grouping variables as needed.
  - the former functionality in `compute_loanbook_targets()` was one pipe, which is now split into multiple parts.
  - the first part is only the right_join that was previously used too
  - the latter part of the pipe also stays intact
  - we add an intermediate step that is triggered in case targets are calculated on the company level. This optional step ensures the adjusted `scenario_with_p` values are correctly merged for every individual company, ensuring the relevant convergence value exists when calculating company targets
- the snapshot for the company level `target_sda()` calculation is updated, as it previously contained NAs and wrong values due to this bug