### PR TITLE
Fill NAs with zero in `abcd`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # r2dii.analysis (development version)
 
+* `target_market_share` now filters out `abcd` rows where `production` is `NA` (#423).
+
 # r2dii.analysis 0.3.0
 
 * `target_sda` now uses final year of scenario as convergence target when `by_company = TRUE` (#445).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # r2dii.analysis (development version)
 
-* `target_market_share` now filters out `abcd` rows where `production` is `NA` (#423).
+* `target_market_share` now handles `abcd` with rows where `production` is `NA` by filling with `0` (#423).
 
 # r2dii.analysis 0.3.0
 

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -106,7 +106,7 @@ target_market_share <- function(data,
 
   data <- rename_and_warn_ald_names(data)
 
-  abcd <- filter_and_warn_na(abcd, "production")
+  abcd <- fill_and_warn_na(abcd, "production")
 
   region_isos <- change_to_lowercase_and_warn(region_isos, "isos")
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -23,6 +23,20 @@ filter_and_warn_na <- function(data, column) {
   return(data)
 }
 
+fill_and_warn_na <- function(data, column) {
+  if (anyNA(data[[column]])) {
+    name_dataset <- deparse(substitute(data))
+    warning_message = paste("Filling in rows of", name_dataset, "where `{column}` is NA with 0")
+    warn(
+      glue(warning_message),
+      class = "fill_nas_crucial_economic_input"
+    )
+
+    data <- mutate(data, across(.data[[column]], ~tidyr::replace_na(., 0)))
+  }
+  return(data)
+}
+
 warn_grouped <- function(data, message) {
   if (dplyr::is_grouped_df(data)) warn(message)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,7 +32,7 @@ fill_and_warn_na <- function(data, column) {
       class = "fill_nas_crucial_economic_input"
     )
 
-    data <- mutate(data, across(.data[[column]], ~tidyr::replace_na(., 0)))
+    data[[column]] <- tidyr::replace_na(data[[column]], 0)
   }
   return(data)
 }

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -1411,7 +1411,7 @@ test_that("region_isos only has lowercase isos #398", {
   )
 })
 
-test_that("with `abcd` with `NA` for start year, replaces `NA` with 0", {
+test_that("with `abcd` with `NA` for start year, replaces `NA` with 0 (#423)", {
   expect_warning(
     out <- target_market_share(
       fake_matched(),

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -169,7 +169,7 @@ test_that("w/ NAs in crucial columns, errors with informative message", {
   expect_error_crucial_NAs_scenario("smsp")
 })
 
-test_that("filters and warns when input-data has NAs", {
+test_that("fills and warns when input-data has NAs", {
   matched <- fake_matched()
   abcd <- fake_abcd(production = c(1, NA))
   scenario <- fake_scenario()
@@ -180,7 +180,7 @@ test_that("filters and warns when input-data has NAs", {
       abcd,
       scenario,
       region_isos_stable),
-      class = "na_crucial_economic_input")
+      class = "fill_nas_crucial_economic_input")
 })
 
 test_that("outputs expected names", {

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -1410,3 +1410,21 @@ test_that("region_isos only has lowercase isos #398", {
     )
   )
 })
+
+test_that("with `abcd` with `NA` for start year, replaces `NA` with 0", {
+  expect_warning(
+    out <- target_market_share(
+      fake_matched(),
+      fake_abcd(year = c(2020, 2025), production = c(NA_real_, 1)),
+      fake_scenario(year = c(2020, 2025)),
+      region_isos_stable
+    ),
+    class = "fill_nas_crucial_economic_input"
+  )
+
+  out <- out %>%
+    filter(metric == "projected") %>%
+    arrange(year)
+
+  expect_equal(out$production, c(0, 1))
+})


### PR DESCRIPTION
This PR adjusts the expected behaviour of `target_market_share` in how it handles input `abcd` data when `abcd$production` contains `NA`s. Previously it would filter these rows and remove from analysis. Now, it replaces them with `0`. 

@jacobvjk I have a follow-up question, which is, do we want `target_sda` to exhibit the same behaviour? I imagine probably we do. 

and @cjyetman I wanted your input here, do you think this is a reasonable thing to do? (see linked issue for more reference). I know there are, in general, fears around replacing `NA`s with 0s willy nilly, but I think in this particular case, we do actually expect that PAMS data with `NA` production values DO mean 0 production... Especially if the asset has not "turned on" yet.


Closes #423 