### PR TITLE
`target_market_share` now correctly handles input `scenario` with a hyphen in name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # r2dii.analysis (development version)
 
+* `target_market_share` now correctly handles input scenarios with a hyphen in their name (#425).
+
 # r2dii.analysis 0.3.0
 
 * `target_sda` now uses final year of scenario as convergence target when `by_company = TRUE` (#445).

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -450,7 +450,12 @@ separate_metric_from_name <- function(data) {
       name = sub("(production)_", "\\1-", .data$name),
       name = sub("(technology_share)_", "\\1-", .data$name)
     ) %>%
-    tidyr::separate(.data$name, into = c("name", "metric"), sep = "-")
+    tidyr::separate(
+      .data$name,
+      into = c("name", "metric"),
+      sep = "-",
+      extra = "merge"
+      )
 }
 
 check_input_for_crucial_columns <- function(data, abcd, scenario) {

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -1410,3 +1410,17 @@ test_that("region_isos only has lowercase isos #398", {
     )
   )
 })
+
+test_that("correctly splits scenario names with hyphen #425", {
+
+  out <- target_market_share(
+    fake_matched(),
+    fake_abcd(),
+    fake_scenario(scenario = "1.5c-scen"),
+    region_isos_stable
+  ) %>%
+    filter(grepl("target", metric))
+
+  expect_equal(unique(out$metric), "target_1.5c-scen")
+
+})


### PR DESCRIPTION
Closes #425 