### PR TITLE
upkeep: `add_green_technologies_to_abcd` only adds techs if they are not already there

### DIFF
--- a/R/join_abcd_scenario.R
+++ b/R/join_abcd_scenario.R
@@ -103,6 +103,11 @@ add_green_technologies_to_abcd <- function(data, scenario) {
     unique() %>%
     inner_join(increasing_techs, by = c("sector", "technology"))
 
+  increasing_techs_not_in_abcd <- dplyr::filter(
+    increasing_techs_in_scenario,
+    !(technology %in% unique(data$technology))
+  )
+
   green_rows_to_add <- data %>%
     group_by(
       .data$name_company,
@@ -113,7 +118,7 @@ add_green_technologies_to_abcd <- function(data, scenario) {
     ) %>%
     summarize() %>%
     left_join(
-      increasing_techs_in_scenario,
+      increasing_techs_not_in_abcd,
       by = "sector",
       relationship = "many-to-many"
       ) %>%


### PR DESCRIPTION
While working on a separate PR, I noticed some odd behaviour of this internal function. 

The point of `add_green_technologies_to_abcd` is to add green technologies to a matched input dataset if they are not already present. This serves to ensure that green technologies always get a forward-looking target (as is the expectation of SMSP). 

However, this function was erroneously adding the technologies no matter what (even if they were already present in the input). I guess this problem was evened out somewhere else in some call to `summarize`, but I figured it makes sense to just fix it where it happens.

See https://github.com/RMI-PACTA/r2dii.analysis/issues/318 for more info. 

No related issue. 
