### PR TITLE
add correct missing low carbon technologies to abcd

### DIFF
--- a/R/join_abcd_scenario.R
+++ b/R/join_abcd_scenario.R
@@ -160,11 +160,13 @@ add_green_technologies_to_abcd <- function(data, scenario) {
     unique() %>%
     inner_join(increasing_techs, by = c("sector", "technology"))
 
-  increasing_techs_not_in_abcd <- dplyr::filter(
+  increasing_techs_not_in_abcd <- dplyr::anti_join(
     increasing_techs_in_scenario,
-    !(.data[["technology"]] %in% unique(data$technology))
+    data,
+    by = c("sector", "technology")
   )
 
+  # TODO: the summarize should be replaced with a distinct. the left_join should be an inner_join to avoid adding NAs
   green_rows_to_add <- data %>%
     group_by(
       .data$name_company,

--- a/R/join_abcd_scenario.R
+++ b/R/join_abcd_scenario.R
@@ -166,7 +166,6 @@ add_green_technologies_to_abcd <- function(data, scenario) {
     by = c("sector", "technology")
   )
 
-  # TODO: the summarize should be replaced with a distinct. the left_join should be an inner_join to avoid adding NAs
   green_rows_to_add <- data %>%
     group_by(
       .data$name_company,

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -1496,9 +1496,10 @@ test_that("with duplicated id_loan throws informative error (#489)", {
 })
 
 test_that("target_market_share() calculates target_* values for missing low carbon technologies (#495)", {
-  match_result <- fake_matched()
+  match_result <- fake_matched(name_abcd = "company a")
 
   abcd <- fake_abcd(
+    name_company = "company a",
     sector = c(rep("automotive", 2), rep("hdv", 6)),
     technology = c(rep("ice", 4), rep("hybrid", 2), rep("electric", 2)),
     year = rep(c(2020, 2025), 4)
@@ -1512,15 +1513,24 @@ test_that("target_market_share() calculates target_* values for missing low carb
     smsp = c(0, -0.08, 0, 0.1, 0, 0.1)
   )
 
-  results_tms_lbk <- target_market_share(
+  scen_technologies <- scen %>%
+    dplyr::filter(.data$sector == "automotive") %>%
+    dplyr::arrange(.data$technology) %>%
+    dplyr::distinct(.data$technology) %>%
+    dplyr::pull()
+
+  results_tms_comp <- target_market_share(
     match_result,
     abcd,
     scen,
-    region_isos = region_isos_stable
+    region_isos = region_isos_stable,
+    by_company = TRUE,
+    weight_production = FALSE
   )
 
-  results_tms_lbk_targets <- results_tms_lbk %>%
+  results_tms_comp_targets <- results_tms_comp %>%
     dplyr::filter(
+      .data$name_abcd == "company a",
       .data$sector == "automotive",
       grepl("target_", .data$metric)
     ) %>%
@@ -1528,8 +1538,25 @@ test_that("target_market_share() calculates target_* values for missing low carb
     dplyr::distinct(.data$technology) %>%
     dplyr::pull()
 
-  scen_technologies <- scen %>%
-    dplyr::filter(.data$sector == "automotive") %>%
+  expect_equal(
+    results_tms_comp_targets,
+    scen_technologies
+  )
+
+  results_tms_lbk <- target_market_share(
+    match_result,
+    abcd,
+    scen,
+    region_isos = region_isos_stable,
+    by_company = FALSE,
+    weight_production = TRUE
+  )
+
+  results_tms_lbk_targets <- results_tms_lbk %>%
+    dplyr::filter(
+      .data$sector == "automotive",
+      grepl("target_", .data$metric)
+    ) %>%
     dplyr::arrange(.data$technology) %>%
     dplyr::distinct(.data$technology) %>%
     dplyr::pull()

--- a/tests/testthat/test-target_market_share.R
+++ b/tests/testthat/test-target_market_share.R
@@ -1494,3 +1494,48 @@ test_that("with duplicated id_loan throws informative error (#489)", {
     class = "unique_ids"
   )
 })
+
+test_that("target_market_share() calculates target_* values for missing low carbon technologies (#495)", {
+  match_result <- fake_matched()
+
+  abcd <- fake_abcd(
+    sector = c(rep("automotive", 2), rep("hdv", 6)),
+    technology = c(rep("ice", 4), rep("hybrid", 2), rep("electric", 2)),
+    year = rep(c(2020, 2025), 4)
+  )
+
+  scen <- fake_scenario(
+    sector = "automotive",
+    technology = c(rep("ice", 2), rep("hybrid", 2), rep("electric", 2)),
+    year = rep(c(2020, 2025), 3),
+    tmsr = c(1, 0.5, 1, 1.5, 1, 1.5),
+    smsp = c(0, -0.08, 0, 0.1, 0, 0.1)
+  )
+
+  results_tms_lbk <- target_market_share(
+    match_result,
+    abcd,
+    scen,
+    region_isos = region_isos_stable
+  )
+
+  results_tms_lbk_targets <- results_tms_lbk %>%
+    dplyr::filter(
+      .data$sector == "automotive",
+      grepl("target_", .data$metric)
+    ) %>%
+    dplyr::arrange(.data$technology) %>%
+    dplyr::distinct(.data$technology) %>%
+    dplyr::pull()
+
+  scen_technologies <- scen %>%
+    dplyr::filter(.data$sector == "automotive") %>%
+    dplyr::arrange(.data$technology) %>%
+    dplyr::distinct(.data$technology) %>%
+    dplyr::pull()
+
+  expect_equal(
+    results_tms_lbk_targets,
+    scen_technologies
+  )
+})


### PR DESCRIPTION
closes #495 

- `target_market_share()` gains handling that identifies missing low carbon technologies by sector, not overall. This ensures that scenario targets for the companies in the loan book that have missing low carbon technologies will be calculated and returned, even if the company has another sector that does have production values in technologies of the same names as the missing ones.