### PR TITLE
disable compare version check

### DIFF
--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -22,6 +22,7 @@ jobs:
     uses: RMI-PACTA/actions/.github/workflows/R.yml@main
     secrets: inherit
     with:
+      do-compare-versions: false
       revdeps: |
           [
             {"pkg": "RMI-PACTA/r2dii.plot"},


### PR DESCRIPTION
- following https://github.com/RMI-PACTA/r2dii.match/pull/504

The compare version action checks for a practice that does not appear to be widely/consistently used in this repo.