### PR TITLE
Soft deprecate funs

### DIFF
--- a/R/join_abcd_scenario.R
+++ b/R/join_abcd_scenario.R
@@ -1,8 +1,18 @@
 #' Join a data-loanbook object to the abcd and scenario
 #'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
+#' This function was deprecated because it is not required as a user-facing
+#' function for PACTA for Banks. It is still used internally though.
+#' All relevant outputs of the PACTA for Banks analysis can be obtained using
+#' the target_market_share() and target_sda() functions.
+#'
 #' `join_abcd_scenario()` is a simple wrapper of several calls to
 #' `dplyr::join_*()`, forming the master dataset to be used in later steps of
 #' the analysis.
+#'
+#' @keywords internal
 #'
 #' @param data A data frame like the output of
 #'   `r2dii.match::prioritize`.
@@ -39,6 +49,7 @@ join_abcd_scenario <- function(data,
                               scenario,
                               region_isos = r2dii.data::region_isos,
                               add_green_technologies = FALSE) {
+  lifecycle::deprecate_soft(when = "0.5.0", what = "join_abcd_scenario()")
 
   check_portfolio_abcd_scenario(data, abcd, scenario)
 

--- a/R/summarize_weighted_production.R
+++ b/R/summarize_weighted_production.R
@@ -1,8 +1,20 @@
 #' Summaries based on the weight of each loan per sector per year
 #'
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
+#' These functions (summarize_weighted_production() and
+#' summarize_weighted_percent_change()) were deprecated because they are not
+#' required as a user-facing function for PACTA for Banks.
+#' They are still used internally though.
+#' All relevant outputs of the PACTA for Banks analysis can be obtained using
+#' the target_market_share() and target_sda() functions.
+#'
 #' Based on on the weight of each loan per sector per year,
 #' `summarize_weighted_production()` and `summarize_weighted_percent_change()`
 #' summarize the production and percent-change, respectively.
+#'
+#' @keywords internal
 #'
 #' @param data A data frame like the output of [join_abcd_scenario()].
 #' @param use_credit_limit Logical vector of length 1. `FALSE` defaults to using
@@ -50,6 +62,7 @@
 #'
 #' summarize_weighted_percent_change(master, use_credit_limit = TRUE)
 summarize_weighted_production <- function(data, ..., use_credit_limit = FALSE) {
+  lifecycle::deprecate_soft(when = "0.5.0", what = "summarize_weighted_production()")
   summarize_weighted_production_(data, ..., use_credit_limit = use_credit_limit, with_targets = FALSE)
 }
 
@@ -145,6 +158,7 @@ summarize_unweighted_production <- function(data, ..., with_targets = FALSE) {
 #' @rdname summarize_weighted_production
 #' @export
 summarize_weighted_percent_change <- function(data, ..., use_credit_limit = FALSE) {
+  lifecycle::deprecate_soft(when = "0.5.0", what = "summarize_weighted_percent_change()")
   stopifnot(is.data.frame(data))
 
   data %>%

--- a/man/join_abcd_scenario.Rd
+++ b/man/join_abcd_scenario.Rd
@@ -32,6 +32,13 @@ Returns a fully joined data frame, linking portfolio, abcd and
 scenario.
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
+This function was deprecated because it is not required as a user-facing
+function for PACTA for Banks. It is still used internally though.
+All relevant outputs of the PACTA for Banks analysis can be obtained using
+the target_market_share() and target_sda() functions.
+
 \code{join_abcd_scenario()} is a simple wrapper of several calls to
 \verb{dplyr::join_*()}, forming the master dataset to be used in later steps of
 the analysis.
@@ -58,3 +65,4 @@ Other utility functions:
 \code{\link{summarize_weighted_production}()}
 }
 \concept{utility functions}
+\keyword{internal}

--- a/man/summarize_weighted_production.Rd
+++ b/man/summarize_weighted_production.Rd
@@ -25,6 +25,15 @@ A tibble with the same groups as the input (if any) and columns:
 \code{summarize_weighted_percent_change()}, respectively.
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
+These functions (summarize_weighted_production() and
+summarize_weighted_percent_change()) were deprecated because they are not
+required as a user-facing function for PACTA for Banks.
+They are still used internally though.
+All relevant outputs of the PACTA for Banks analysis can be obtained using
+the target_market_share() and target_sda() functions.
+
 Based on on the weight of each loan per sector per year,
 \code{summarize_weighted_production()} and \code{summarize_weighted_percent_change()}
 summarize the production and percent-change, respectively.
@@ -69,3 +78,4 @@ Other utility functions:
 \code{\link{join_abcd_scenario}()}
 }
 \concept{utility functions}
+\keyword{internal}


### PR DESCRIPTION
relates to #468 

* `join_abcd_scenario()` is soft-deprecated
* `summarize_weighted_production()` and `summarize_weighted_percent_change()` are soft-deprecated
* following the process as described here https://lifecycle.r-lib.org/articles/communicate.html#deprecate-a-function