### PR TITLE
Update tests of deprecated functions

### DIFF
--- a/R/join_abcd_scenario.R
+++ b/R/join_abcd_scenario.R
@@ -35,22 +35,35 @@
 #' library(r2dii.match)
 #'
 #' valid_matches <- match_name(loanbook_demo, abcd_demo) %>%
-#' # WARNING: Remember to validate matches (see `?prioritize`)
+#'   # WARNING: Remember to validate matches (see `?prioritize`)
 #'   prioritize()
 #'
 #' valid_matches %>%
 #'   join_abcd_scenario(
-#'   abcd = abcd_demo,
-#'   scenario = scenario_demo_2020,
-#'   region_isos = region_isos_demo
+#'     abcd = abcd_demo,
+#'     scenario = scenario_demo_2020,
+#'     region_isos = region_isos_demo
 #'   )
 join_abcd_scenario <- function(data,
-                              abcd,
-                              scenario,
-                              region_isos = r2dii.data::region_isos,
-                              add_green_technologies = FALSE) {
+                               abcd,
+                               scenario,
+                               region_isos = r2dii.data::region_isos,
+                               add_green_technologies = FALSE) {
   lifecycle::deprecate_soft(when = "0.5.0", what = "join_abcd_scenario()")
+  join_abcd_scenario_(
+    data,
+    abcd = abcd,
+    scenario = scenario,
+    region_isos = region_isos,
+    add_green_technologies = add_green_technologies
+  )
+}
 
+join_abcd_scenario_ <- function(data,
+                                abcd,
+                                scenario,
+                                region_isos = r2dii.data::region_isos,
+                                add_green_technologies = FALSE) {
   check_portfolio_abcd_scenario(data, abcd, scenario)
 
   # Track provenance to avoid clash in the column name "source"
@@ -69,7 +82,7 @@ join_abcd_scenario <- function(data,
     mutate(
       .start_year_abcd = first(.data[["year"]]),
       .by = c("name_company", "sector", "plant_location")
-      )
+    )
 
   scenario <- scenario %>%
     arrange(.data[["year"]]) %>%
@@ -118,7 +131,7 @@ join_abcd_scenario <- function(data,
     dplyr::mutate(
       .start_year_abcd = NULL,
       .start_year_scenario = NULL
-      )
+    )
 
   out <- data %>%
     mutate(plant_location = tolower(.data$plant_location)) %>%
@@ -152,7 +165,7 @@ check_portfolio_abcd_scenario <- function(valid_matches, abcd, scenario) {
   check_crucial_names(
     scenario,
     c(scenario_columns(), "scenario_source", "region", "year")
-    )
+  )
   walk_(
     c(scenario_columns(), "scenario_source", "region", "year"),
     ~ check_no_value_is_missing(scenario, .x)
@@ -190,7 +203,7 @@ add_green_technologies_to_abcd <- function(data, scenario) {
       increasing_techs_not_in_abcd,
       by = "sector",
       relationship = "many-to-many"
-      ) %>%
+    ) %>%
     mutate(production = 0)
 
   dplyr::bind_rows(data, green_rows_to_add)

--- a/R/target_market_share.R
+++ b/R/target_market_share.R
@@ -112,7 +112,7 @@ target_market_share <- function(data,
     return(scenario)
   }
 
-  data <- join_abcd_scenario(
+  data <- join_abcd_scenario_(
     data,
     abcd,
     scenario,

--- a/man/join_abcd_scenario.Rd
+++ b/man/join_abcd_scenario.Rd
@@ -49,14 +49,14 @@ library(r2dii.data)
 library(r2dii.match)
 
 valid_matches <- match_name(loanbook_demo, abcd_demo) \%>\%
-# WARNING: Remember to validate matches (see `?prioritize`)
+  # WARNING: Remember to validate matches (see `?prioritize`)
   prioritize()
 
 valid_matches \%>\%
   join_abcd_scenario(
-  abcd = abcd_demo,
-  scenario = scenario_demo_2020,
-  region_isos = region_isos_demo
+    abcd = abcd_demo,
+    scenario = scenario_demo_2020,
+    region_isos = region_isos_demo
   )
 \dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/test-join_abcd_scenario.R
+++ b/tests/testthat/test-join_abcd_scenario.R
@@ -2,6 +2,7 @@ library(dplyr, warn.conflicts = FALSE)
 library(r2dii.data)
 
 test_that("with fake data outputs known value", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   out <- join_abcd_scenario(
     fake_matched(),
     abcd = fake_abcd(),
@@ -12,6 +13,7 @@ test_that("with fake data outputs known value", {
 })
 
 test_that("returns visibly", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   expect_visible(
     join_abcd_scenario(
       fake_matched(),
@@ -23,6 +25,8 @@ test_that("returns visibly", {
 })
 
 test_that("outputs expected names", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   expected <- setdiff(
     c(
       names(fake_matched()),
@@ -58,6 +62,8 @@ test_that("outputs expected names", {
 })
 
 test_that("is sensitive to region_isos", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   out1 <- join_abcd_scenario(
     fake_matched(),
     abcd = fake_abcd(),
@@ -76,6 +82,8 @@ test_that("is sensitive to region_isos", {
 })
 
 test_that("is case-insensitive to `plant_location` inputs", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   lowercase <- "a"
   out1 <- join_abcd_scenario(
     fake_matched(),
@@ -96,6 +104,8 @@ test_that("is case-insensitive to `plant_location` inputs", {
 })
 
 test_that("outputs a number of rows equal to matches by `scenario_source`", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   matching_0 <- suppressWarnings(
     join_abcd_scenario(
       fake_matched(),
@@ -129,6 +139,7 @@ test_that("w/ loanbook, abcd or scenario with missing names errors gracefully", 
   expect_error_missing_names <- function(match_result = fake_matched(),
                                          abcd = fake_abcd(),
                                          scenario = fake_scenario()) {
+    withr::local_options(lifecycle_verbosity = "quiet")
     expect_error(
       class = "missing_names",
       join_abcd_scenario(match_result, abcd, scenario)
@@ -151,6 +162,8 @@ test_that("w/ loanbook, abcd or scenario with missing names errors gracefully", 
 })
 
 test_that("without `sector` throws no error", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   # RMI-PACTA/r2dii.analysis/pull/62#issuecomment-634651157
   without_sector <- select(fake_matched(), -sector)
   expect_error_free(
@@ -164,6 +177,8 @@ test_that("without `sector` throws no error", {
 })
 
 test_that("warns 0-rows caused by scenario or region_isos", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   join_abcd_scenario2 <- function(l, scenario = NULL, region_isos = NULL) {
     scenario <- scenario %||% fake_scenario(
       region = l$region, sector = l$sector, scenario_source = l$source
@@ -216,6 +231,8 @@ test_that("warns 0-rows caused by scenario or region_isos", {
 })
 
 test_that("include/excludes `plant_location` inside/outside a region", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   # styler: off
   region_isos_toy <- dplyr::tribble(
     ~region,         ~isos, ~source,
@@ -244,6 +261,8 @@ test_that("include/excludes `plant_location` inside/outside a region", {
 })
 
 test_that("outputs the same with upper/lower abcd$sector or abcd$technology", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   matched <- fake_matched()
   abcd <- fake_abcd()
   scenario <- fake_scenario()
@@ -261,6 +280,7 @@ test_that("outputs the same with upper/lower abcd$sector or abcd$technology", {
 })
 
 test_that("outputs full timeline of scenario #157", {
+  withr::local_options(lifecycle_verbosity = "quiet")
 
   out <- join_abcd_scenario(
     fake_matched(),
@@ -274,6 +294,7 @@ test_that("outputs full timeline of scenario #157", {
 })
 
 test_that("doesnt output sectors that aren't in input data #157", {
+  withr::local_options(lifecycle_verbosity = "quiet")
 
   out <- join_abcd_scenario(
     fake_matched(sector_abcd = "power"),
@@ -290,6 +311,7 @@ test_that("doesnt output sectors that aren't in input data #157", {
 })
 
 test_that("only extend timeline beyond t0 of abcd #157", {
+  withr::local_options(lifecycle_verbosity = "quiet")
 
   out <- join_abcd_scenario(
     fake_matched(name_abcd = c("a", "b")),
@@ -318,6 +340,8 @@ test_that("only extend timeline beyond t0 of abcd #157", {
 })
 
 test_that("columns in output match what is documented in `data_dictionary`", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   out <- join_abcd_scenario(
     data = fake_matched(),
     abcd = fake_abcd(),
@@ -329,4 +353,16 @@ test_that("columns in output match what is documented in `data_dictionary`", {
 
   expect_setequal(names(out), data_dict[["column"]])
   expect_mapequal(sapply(out, typeof), setNames(data_dict[["typeof"]], data_dict[["column"]]))
+})
+
+test_that("join_abcd_scenario throws a deprecation warning", {
+  expect_warning(
+    join_abcd_scenario(
+      fake_matched(),
+      abcd = fake_abcd(),
+      scenario = fake_scenario(),
+      region_isos = region_isos_stable
+    ),
+    "deprecated in r2dii.analysis 0.5.0"
+  )
 })

--- a/tests/testthat/test-summarize_weighted_production.R
+++ b/tests/testthat/test-summarize_weighted_production.R
@@ -4,10 +4,12 @@ library(r2dii.match)
 # Production --------------------------------------------------------------
 
 test_that("with bad `data` errors with informative message", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   expect_error(summarize_weighted_production("bad"), "data.frame.*not.*TRUE")
 })
 
 test_that("with bad use_credit_limit errors with informative message", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   expect_error(
     summarize_weighted_production(fake_master(), use_credit_limit = "bad"),
     "not TRUE"
@@ -30,6 +32,7 @@ test_that("with bad use_credit_limit errors with informative message", {
 })
 
 test_that("with data lacking crucial columns errors with informative message", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   expect_error_missing_names <- function(name, use_credit_limit = FALSE) {
     data <- rename(fake_master(), bad = all_of(name))
 
@@ -47,8 +50,8 @@ test_that("with data lacking crucial columns errors with informative message", {
   expect_error_missing_names("technology")
   expect_error_missing_names("year")
 })
-
 test_that("with NAs in crucial columns errors with informative message", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   expect_error_crucial_NAs <- function(name, use_credit_limit = FALSE) {
     data <- fake_master(
       technology = c("ta", "ta", "tb", "tb"),
@@ -73,6 +76,7 @@ test_that("with NAs in crucial columns errors with informative message", {
 })
 
 test_that("with bad but unused loan_size_column is error free", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   bad_unused <- rename(fake_master(), bad = "loan_size_credit_limit")
   expect_error_free(
     summarize_weighted_production(bad_unused, use_credit_limit = FALSE)
@@ -85,6 +89,7 @@ test_that("with bad but unused loan_size_column is error free", {
 })
 
 test_that("with duplicated loan_size by id_loan throws error", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   expect_error(
     class = "multiple_loan_size_values_by_id_loan",
     summarize_weighted_production(fake_master(loan_size_outstanding = 1:2))
@@ -100,6 +105,7 @@ test_that("with duplicated loan_size by id_loan throws error", {
 })
 
 test_that("with known input outputs as expected", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   # styler: off
   data <- fake_master(
     technology =            c("ta", "ta", "tb", "tb"),
@@ -125,6 +131,7 @@ test_that("with known input outputs as expected", {
 })
 
 test_that("outputs expected names", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   expect_named(
     summarize_weighted_production(fake_master()),
     c(
@@ -138,6 +145,7 @@ test_that("outputs expected names", {
 })
 
 test_that("with multiple years outputs as expected", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   # styler: off
   data <- fake_master(
     technology =            c("ta", "ta"),
@@ -161,6 +169,7 @@ test_that("with multiple years outputs as expected", {
 })
 
 test_that("with grouped data returns same groups as input", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   out <- fake_master() %>%
     group_by(.data$sector_abcd) %>%
     summarize_weighted_production()
@@ -169,12 +178,14 @@ test_that("with grouped data returns same groups as input", {
 })
 
 test_that("can group by `plant_location`", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   data <- fake_master(plant_location = c("a", "b"))
   out <- summarize_weighted_production(data, plant_location)
   expect_equal(nrow(out), 2L)
 })
 
 test_that("preserves groups passed to ...", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   data <- fake_master(plant_location = c("a", "b")) %>%
     group_by(plant_location)
 
@@ -187,6 +198,7 @@ test_that("preserves groups passed to ...", {
 # Percent-change ---------------------------------------------------------------
 
 test_that("with bad `data` errors with informative message", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   expect_error(
     summarize_weighted_percent_change("bad"),
     "data.frame.*not.*TRUE"
@@ -194,6 +206,8 @@ test_that("with bad `data` errors with informative message", {
 })
 
 test_that("with bad use_credit_limit errors with informative message", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   expect_error(
     summarize_weighted_percent_change(fake_master(), use_credit_limit = "bad"),
     "not TRUE"
@@ -216,6 +230,8 @@ test_that("with bad use_credit_limit errors with informative message", {
 })
 
 test_that("with data lacking crucial columns errors with informative message", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   expect_error_missing_names <- function(name, use_credit_limit = FALSE) {
     data <- rename(fake_master(), bad = all_of(name))
 
@@ -247,6 +263,7 @@ test_that("with NAs in crucial columns errors with informative message", {
     )
 
     data[1, name] <- NA
+    withr::local_options(lifecycle_verbosity = "quiet")
     expect_error(
       class = "some_value_is_missing",
       summarize_weighted_percent_change(
@@ -265,6 +282,8 @@ test_that("with NAs in crucial columns errors with informative message", {
 })
 
 test_that("with bad but unused loan_size_column is error free", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   bad_unused <- rename(fake_master(), bad = "loan_size_credit_limit")
   expect_error_free(
     summarize_weighted_percent_change(bad_unused, use_credit_limit = FALSE)
@@ -277,6 +296,8 @@ test_that("with bad but unused loan_size_column is error free", {
 })
 
 test_that("with duplicated loan_size by id_loan throws error", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   expect_error(
     class = "multiple_loan_size_values_by_id_loan",
     summarize_weighted_percent_change(fake_master(loan_size_outstanding = 1:2))
@@ -292,6 +313,7 @@ test_that("with duplicated loan_size by id_loan throws error", {
 })
 
 test_that("outputs expected names", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   expect_named(
     summarize_weighted_percent_change(fake_master()),
     c("sector_abcd", "technology", "year", "weighted_percent_change")
@@ -299,6 +321,8 @@ test_that("outputs expected names", {
 })
 
 test_that("is sensitive to `use_credit_limit`", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   data <- fake_master(
     name_abcd = rep(c("company a", "company b"), 2),
     year = c(2020, 2020, 2021, 2021),
@@ -315,6 +339,8 @@ test_that("is sensitive to `use_credit_limit`", {
 })
 
 test_that("with grouped data returns same groups as input", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   out <- fake_master() %>%
     group_by(.data$sector_abcd) %>%
     summarize_weighted_percent_change()
@@ -323,12 +349,14 @@ test_that("with grouped data returns same groups as input", {
 })
 
 test_that("can group by `plant_location`", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   data <- fake_master(plant_location = c("a", "b"))
   out <- summarize_weighted_percent_change(data, plant_location)
   expect_equal(nrow(out), 2L)
 })
 
 test_that("outputs names that include two grouping columns", {
+  withr::local_options(lifecycle_verbosity = "quiet")
   data <- fake_master(plant_location = c("a", "b"))
   out <- summarize_weighted_percent_change(data, plant_location, region)
 
@@ -338,6 +366,8 @@ test_that("outputs names that include two grouping columns", {
 })
 
 test_that("preserves groups passed to ...", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   data <- fake_master(plant_location = c("a", "b")) %>%
     group_by(plant_location)
 
@@ -348,6 +378,8 @@ test_that("preserves groups passed to ...", {
 })
 
 test_that("with zero initial production errors with informative message", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   data <- fake_master(production = 0)
 
   expect_error(
@@ -357,6 +389,8 @@ test_that("with zero initial production errors with informative message", {
 })
 
 test_that("with known input outputs as expected", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   data <- fake_master(
     name_abcd = rep(c("company a", "company b"), 2),
     year = c(2020, 2020, 2021, 2021),
@@ -382,6 +416,8 @@ test_that("with known input outputs as expected", {
 })
 
 test_that("with different currencies errors with informative message (#137)", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   # styler: off
   data <- fake_master(
     id_loan = c(1,2),
@@ -403,6 +439,8 @@ test_that("with different currencies errors with informative message (#137)", {
 })
 
 test_that("columns in output match what is documented in `data_dictionary`", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   out <- summarize_weighted_production(data = fake_master())
 
   data_dict <- dplyr::filter(r2dii.analysis::data_dictionary, dataset == "summarize_weighted_production_output")
@@ -412,10 +450,26 @@ test_that("columns in output match what is documented in `data_dictionary`", {
 })
 
 test_that("columns in output match what is documented in `data_dictionary`", {
+  withr::local_options(lifecycle_verbosity = "quiet")
+
   out <- summarize_weighted_percent_change(data = fake_master())
 
   data_dict <- dplyr::filter(r2dii.analysis::data_dictionary, dataset == "summarize_weighted_percent_change_output")
 
   expect_setequal(names(out), data_dict[["column"]])
   expect_mapequal(sapply(out, typeof), setNames(data_dict[["typeof"]], data_dict[["column"]]))
+})
+
+test_that("summarize_weighted_production throws a deprecation warning", {
+  expect_warning(
+    summarize_weighted_production(fake_master()),
+    "deprecated in r2dii.analysis 0.5.0"
+  )
+})
+
+test_that("summarize_weighted_percent_change throws a deprecation warning", {
+  expect_warning(
+    summarize_weighted_percent_change(fake_master()),
+    "deprecated in r2dii.analysis 0.5.0"
+  )
 })


### PR DESCRIPTION
* updates tests of deprecated functions following https://lifecycle.r-lib.org/articles/communicate.html#deprecate-a-function (but using expect_warning instead of adding a snapshot test)
* turns the deprecated function `join_abcd_scenario()` into a wrapper around the new internal function `join_abcd_scenario_()` (following the same structure applied for `summarize_weighted_production()`). This allows quelling deprecation warnings in the tests of the exported function while avoiding warnings being thrown when the internal function is called from within `target_market_share()`