### PR TITLE
skip `data_dictionary` test in `testthat::test_check()` too

### DIFF
--- a/tests/testthat/test-data_dictionary.R
+++ b/tests/testthat/test-data_dictionary.R
@@ -1,6 +1,9 @@
 test_that("matches raw data dictionary CSVs", {
   if (nzchar(Sys.getenv("R_CMD"))) {
-    skip("Not run in R CMD check")
+    skip("Not run in R CMD check (env var `R_CMD` is set)")
+  }
+  if (nzchar(Sys.getenv("TESTTHAT_IS_CHECKING"))) {
+    skip("Not run in `testthat::test_check()` (env var `TESTTHAT_IS_CHECKING` is set)")
   }
   
   paths <- list.files(test_path("../../data-raw/data_dictionary"), full.names = TRUE)


### PR DESCRIPTION
For some reason, env var `R_CMD` is not set when running `testthat::test_check()` (via `covr::package_coverage()`) on Windows, which leads to an error e.g. https://github.com/RMI-PACTA/r2dii.analysis/actions/runs/13330906300/job/37234562139#step:5:50

This uses `testthat::test_check()`'s internal `TESTTHAT_IS_CHECKING` env var because it also [runs the tests in the context of `R CMD check`](https://testthat.r-lib.org/reference/test_package.html)

https://github.com/r-lib/testthat/blob/50a99ec76fed8140a9211ed862289e877e86614d/R/test-package.R#L49

``` r
test_check <- function(package, reporter = check_reporter(), ...) {
  require(package, character.only = TRUE)
  options(cli.hyperlink = FALSE)


  withr::local_envvar(TESTTHAT_IS_CHECKING = "true")


  test_dir(
    "testthat",
    package = package,
    reporter = reporter,
    ...,
    load_package = "installed"
  )
}
```

⚠️ {lintr} is still throwing an error about unrelated things (resolved in #536)