### PR TITLE
add independent {testthat} action so tests that can't run in R CMD check run elsewhere

### DIFF
--- a/.github/workflows/testthat.yaml
+++ b/.github/workflows/testthat.yaml
@@ -1,0 +1,30 @@
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: testthat.yaml
+
+permissions: read-all
+
+jobs:
+  testthat:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::testthat
+
+      - name: run `testthat::test_local()`
+        run: |
+          testthat::test_local()
+        shell: Rscript {0}


### PR DESCRIPTION
as in https://github.com/RMI-PACTA/r2dii.plot/pull/596

proof is no skipped tests in the output of the testthat action: https://github.com/RMI-PACTA/r2dii.analysis/actions/runs/13337776560/job/37256580749?pr=537#step:5:147

Just for clarity, there are 2 tests for the data dictionary currently implemented. One tests that all of the columns do not include NA values, which can run during R CMD check and would have caught the problem that I had not filled in the definitions in the RDA file yet. The second one tests that the RDA file is the same as if one ran the build dictionary script during the test, which cannot run during R CMD check and is the one that's most likely to catch future problems where the CSVs are modified but the submitter forgot to run the build dictionary script to update the RDA file.